### PR TITLE
Emit a metric when pghoard quits main loop

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -879,6 +879,7 @@ class PGHoard:
                 self.metrics.unexpected_exception(ex, where="pghoard_run")
             if self.thread_critical_failure_event.wait(timeout=5.0):
                 self.log.error("Unexpected critical failure in PGHoard thread. Quitting main loop.")
+                self.metrics.increase("pghoard.unrecoverable_quit_main_loop_failure")
                 self.quit()
 
     def write_backup_state_to_json_file(self):


### PR DESCRIPTION
for example: for alerting purpose

# About this change - What it does
Emit a metric when there is unrecoverable error to quit main loop
So we can do some alert on services.


# Why this way
A metric will generate each time if there is a main loop quit.
