### PR TITLE
Drop python 3.7 version since it's broken CI and EOL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - id: checkout-code

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ PGHoard can backup and restore PostgreSQL versions 9.6 and above, but is
 only tested and actively developed with version 10 and above.
 
 The daemon is implemented in Python and is tested and developed with version
-3.7 and above. The following Python modules are required:
+3.8 and above. The following Python modules are required:
 
 * psycopg2_ to look up transaction log metadata
 * requests_ for the internal client-server architecture
@@ -128,24 +128,18 @@ Vagrant
 =======
 
 The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
-python 3.7, 3.8, 3.9 and 3.10 virtual environments and installations of postgresql 10, 11 and 12, 13 and 14.
+python 3.8, 3.9 and 3.10 virtual environments and installations of postgresql 10, 11 and 12, 13 and 14.
 
 By default vagrant up will start a Virtualbox environment. The Vagrantfile will also work for libvirt, just prefix
 ``VAGRANT_DEFAULT_PROVIDER=libvirt`` to the ``vagrant up`` command.
 
-Any combination of Python (3.7, 3.8, 3.9 and 3.10) and Postgresql (10, 11, 12, 13 and 14)
+Any combination of Python (3.8, 3.9 and 3.10) and Postgresql (10, 11, 12, 13 and 14)
 
 Bring up vagrant instance and connect via ssh::
 
   vagrant up
   vagrant ssh
   vagrant@ubuntu2004:~$ cd /vagrant
-
-Test with Python 3.7 and Postgresql 10::
-
-  vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
-  vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
-  vagrant@ubuntu2004:~$ deactivate
 
 Test with Python 3.8 and Postgresql 11::
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
         sed -i "s/^#start_conf.*/start_conf='manual'/g" /etc/postgresql-common/createcluster.conf
         sed -i "s/^#create_main_cluster.*/create_main_cluster=false/g" /etc/postgresql-common/createcluster.conf
 
-        apt-get install -y python{3.7,3.8,3.9,3.10} python{3.7,3.8,3.9,3.10}-dev python{3.7,3.8,3.9,3.10}-venv
+        apt-get install -y python{3.8,3.9,3.10} python{3.8,3.9,3.10}-dev python{3.8,3.9,3.10}-venv
         apt-get install -y postgresql-{10,11,12,13,14} postgresql-server-dev-{10,11,12,13,14}
 
         username="$(< /dev/urandom tr -dc a-z | head -c${1:-32};echo;)"
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: $script, privileged: true
 
     $script = <<-SCRIPT
-        versions=(3.7 3.8 3.9 3.10)
+        versions=(3.8 3.9 3.10)
         for version in "${versions[@]}"; do
             python${version} -m venv venv${version}
             source ~/venv${version}/bin/activate

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -54,24 +54,18 @@ Vagrant
 =======
 
 The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
-python 3.7, 3.8, 3.9 and 3.10 virtual environments and installations of postgresql 10, 11 and 12, 13 and 14.
+python 3.8, 3.9 and 3.10 virtual environments and installations of postgresql 10, 11 and 12, 13 and 14.
 
 By default vagrant up will start a Virtualbox environment. The Vagrantfile will also work for libvirt, just prefix
 ``VAGRANT_DEFAULT_PROVIDER=libvirt`` to the ``vagrant up`` command.
 
-Any combination of Python (3.7, 3.8, 3.9 and 3.10) and Postgresql (10, 11, 12, 13 and 14)
+Any combination of Python (3.8, 3.9 and 3.10) and Postgresql (10, 11, 12, 13 and 14)
 
 Bring up vagrant instance and connect via ssh::
 
   vagrant up
   vagrant ssh
   vagrant@ubuntu2004:~$ cd /vagrant
-
-Test with Python 3.7 and Postgresql 10::
-
-  vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
-  vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
-  vagrant@ubuntu2004:~$ deactivate
 
 Test with Python 3.8 and Postgresql 11::
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         "Intended Audience :: Information Technology",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
# About this change - What it does
Drop the support for python 3.7

Resolves: current broken pipeline issue.
rohmu is python 3.8 above

# Why this way
Python 3.7 is EOL, and pipeline for pghoard is broken because of python 3.7
