### PR TITLE
Update wal_level guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,8 +227,8 @@ After this you need to create a suitable JSON configuration file for your
 installation.
 
 0.  Make sure PostgreSQL is configured to allow WAL archival and retrieval.
-    ``postgresql.conf`` should have ``wal_level`` set to ``archive`` or
-    higher and ``max_wal_senders`` set to at least ``1`` (``archive_command`` mode)
+    ``postgresql.conf`` should have ``wal_level`` set to ``replica`` or
+    ``logical`` and ``max_wal_senders`` set to at least ``1`` (``archive_command`` mode)
     or at least ``2`` (``pg_receivexlog`` and ``walreceiver`` modes), for example::
 
         wal_level = archive


### PR DESCRIPTION
According to the PG docs, 'archive' and 'hot_standby' both redirect to 'replica': https://www.postgresql.org/docs/16/runtime-config-wal.html#GUC-WAL-LEVEL

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
It's confusing for users because those values are no longer valid. It also gives the impression that these values must be changed before running pghoard, but in fact, the default Postgres value (replica) for wal_level is sufficient.


# Why this way

The values ``archive`` and ``hot_standby`` are outdated

