### PR TITLE
Pghoard restore_command optimization

### DIFF
--- a/golang/pghoard_postgres_command_go.go
+++ b/golang/pghoard_postgres_command_go.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"time"
 )
 
@@ -120,15 +121,18 @@ func restore_command(url string, output string, xlog string) (int, error) {
 			}
 			output_path = path.Join(cwd, output)
 		}
-		// if file "<xlog>.pghoard.prefetch" exists, just move it to destination
-		xlogPrefetchPath := path.Join(path.Dir(output_path), xlog+".pghoard.prefetch")
-		_, err = os.Stat(xlogPrefetchPath)
-		if err == nil {
-			err := os.Rename(xlogPrefetchPath, output_path)
-			if err != nil {
-				return EXIT_ABORT, err
+		xlogNameRe := regexp.MustCompile(`^([A-F0-9]{24}|[A-F0-9]{8}\.history)$`)
+		if xlogNameRe.MatchString(xlog) {
+			// if file "<xlog>.pghoard.prefetch" exists, just move it to destination
+			xlogPrefetchPath := path.Join(path.Dir(output_path), xlog+".pghoard.prefetch")
+			_, err = os.Stat(xlogPrefetchPath)
+			if err == nil {
+				err := os.Rename(xlogPrefetchPath, output_path)
+				if err != nil {
+					return EXIT_ABORT, err
+				}
+				return EXIT_OK, nil
 			}
-			return EXIT_OK, nil
 		}
 		req, err = http.NewRequest("GET", url, nil)
 		req.Header.Set("x-pghoard-target-path", output_path)

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -448,8 +448,8 @@ class UnhandledThreadException(Exception):
 
 
 class PGHoardThread(Thread):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name=name)
         self.exception: Optional[Exception] = None
 
     def run_safe(self):

--- a/pghoard/postgres_command.py
+++ b/pghoard/postgres_command.py
@@ -72,6 +72,11 @@ def restore_command(site, xlog, output, host=PGHOARD_HOST, port=PGHOARD_PORT, re
         # directory.  Note that os.path.join strips preceding components if a new components starts with a
         # slash so it's still possible to use this with absolute paths.
         output_path = os.path.join(os.getcwd(), output)
+        # if file "<xlog>.pghoard.prefetch" exists, just move it to destination
+        prefetch_path = os.path.join(os.path.dirname(output_path), xlog + ".pghoard.prefetch")
+        if os.path.exists(prefetch_path):
+            os.rename(prefetch_path, output_path)
+            return
         headers = {"x-pghoard-target-path": output_path}
         method = "GET"
     path = "/{}/archive/{}".format(site, xlog)

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -900,6 +900,7 @@ class TestPGHoardWithPG:
         os.makedirs(wal_directory, exist_ok=True)
 
         pghoard.receivexlog_listener(pghoard.test_site, db.user, wal_directory)
+        time.sleep(0.5)  # waiting for thread setup
         conn = db.connect()
         conn.autocommit = True
 
@@ -918,6 +919,7 @@ class TestPGHoardWithPG:
         # stopping the thread is not enough, it's possible that killed receiver will leave incomplete partial files
         # around, pghoard is capable of cleaning those up but needs to be restarted, for the test it should be OK
         # just to call startup_walk_for_missed_files, so it takes care of cleaning up
+        time.sleep(0.5)  # waiting for the end of file processing
         pghoard.startup_walk_for_missed_files()
 
         n_xlogs = pghoard.transfer_agent_state[pghoard.test_site]["upload"]["xlog"]["xlogs_since_basebackup"]
@@ -930,6 +932,7 @@ class TestPGHoardWithPG:
         # restart
         pghoard.receivexlog_listener(pghoard.test_site, db.user, wal_directory)
         assert pghoard.receivexlogs[pghoard.test_site].is_alive()
+        time.sleep(0.5)  # waiting for thread setup
 
         # We should now process all created segments, not only the ones which were created after pg_receivewal was restarted
         wait_for_xlog(pghoard, n_xlogs + 10)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
Changes:
* Added a new DownloadResultsProcessor thread, which validates downloaded files and saves them to the target: `pg_wal/<wal_name>.tmp -> pg_wal/<wal_name>.pghoard.prefetch`.
Files with "prefetch" suffix can be copied to the destination without extra checks now.
* Renaming prefetched WAL to target is carried out directly in the `pghoard_postgres_command_go`
* changed items type for "pending_download_ops" dict from "dict" to "dataclass" (PendingDownloadOp)

[BF-2247]

We observed that the startup process was only using 60 to 80% of a CPU. This means that we’re not supplying WAL files fast enough or that the restore_command takes too long to complete.
The idea would be to bypass the HTTP-call needed to check if we have a WAL file present from the `restore_command` to the pghoard main process.

