### PR TITLE
pghoard: ignore delta backup failures counter in some cases

### DIFF
--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -104,6 +104,12 @@ class BaseBackupMode(StrEnum):
     pipe = "pipe"
 
 
+@enum.unique
+class BackupReason(StrEnum):
+    requested = "requested"
+    scheduled = "scheduled"
+
+
 class ProgressData(BaseModel):
     current_progress: float = 0
     last_updated_time: float = 0

--- a/test/basebackup/test_basebackup.py
+++ b/test/basebackup/test_basebackup.py
@@ -23,7 +23,7 @@ from rohmu import dates, get_transfer
 
 from pghoard import common, metrics
 from pghoard.basebackup.base import PGBaseBackup
-from pghoard.common import (BaseBackupFormat, BaseBackupMode, CallbackEvent, CallbackQueue)
+from pghoard.common import (BackupReason, BaseBackupFormat, BaseBackupMode, CallbackEvent, CallbackQueue)
 from pghoard.restore import Restore, RestoreError
 
 from ..conftest import PGHoardForTest, PGTester
@@ -240,7 +240,7 @@ LABEL: pg_basebackup base backup
 
         now = datetime.datetime.now(datetime.timezone.utc)
         metadata = {
-            "backup-reason": "scheduled",
+            "backup-reason": BackupReason.scheduled,
             "backup-decision-time": now.isoformat(),
             "normalized-backup-time": now.isoformat(),
         }
@@ -276,7 +276,7 @@ LABEL: pg_basebackup base backup
         assert "start-wal-segment" in last_backup["metadata"]
         assert "start-time" in last_backup["metadata"]
         assert dateutil.parser.parse(last_backup["metadata"]["start-time"]).tzinfo  # pylint: disable=no-member
-        assert last_backup["metadata"]["backup-reason"] == "scheduled"
+        assert last_backup["metadata"]["backup-reason"] == BackupReason.scheduled
         assert last_backup["metadata"]["backup-decision-time"] == now.isoformat()
         assert last_backup["metadata"]["normalized-backup-time"] == now.isoformat()
         if mode in {BaseBackupMode.local_tar, BaseBackupMode.delta}:
@@ -672,7 +672,7 @@ LABEL: pg_basebackup base backup
         pghoard.handle_site(pghoard.test_site, site_config)
         assert pghoard.test_site not in pghoard.basebackups
         first_basebackups = pghoard.state["backup_sites"][pghoard.test_site]["basebackups"]
-        assert first_basebackups[0]["metadata"]["backup-reason"] == "scheduled"
+        assert first_basebackups[0]["metadata"]["backup-reason"] == BackupReason.scheduled
         assert first_basebackups[0]["metadata"]["backup-decision-time"]
         assert first_basebackups[0]["metadata"]["normalized-backup-time"] is None
         first_time_of_check = pghoard.time_of_last_backup_check[pghoard.test_site]
@@ -725,7 +725,7 @@ LABEL: pg_basebackup base backup
         # No backups, one should be created. No backup schedule defined so normalized backup time is None
         metadata = pghoard.get_new_backup_details(now=now, site=pghoard.test_site, site_config=site_config)
         assert metadata
-        assert metadata["backup-reason"] == "scheduled"
+        assert metadata["backup-reason"] == BackupReason.scheduled
         assert metadata["backup-decision-time"] == now.isoformat()
         assert metadata["normalized-backup-time"] is None
 
@@ -734,7 +734,7 @@ LABEL: pg_basebackup base backup
         site_config["basebackup_minute"] = 10
         metadata = pghoard.get_new_backup_details(now=now, site=pghoard.test_site, site_config=site_config)
         assert metadata
-        assert metadata["backup-reason"] == "scheduled"
+        assert metadata["backup-reason"] == BackupReason.scheduled
         assert metadata["backup-decision-time"] == now.isoformat()
         assert "T13:10:00+00:00" in metadata["normalized-backup-time"]
 
@@ -742,7 +742,7 @@ LABEL: pg_basebackup base backup
         site_config["basebackup_interval_hours"] = 1.5
         metadata = pghoard.get_new_backup_details(now=now, site=pghoard.test_site, site_config=site_config)
         assert metadata
-        assert metadata["backup-reason"] == "scheduled"
+        assert metadata["backup-reason"] == BackupReason.scheduled
         assert metadata["backup-decision-time"] == now.isoformat()
         assert "T14:40:00+00:00" in metadata["normalized-backup-time"]
 
@@ -750,7 +750,7 @@ LABEL: pg_basebackup base backup
             "metadata": {
                 "start-time": now - datetime.timedelta(hours=1),
                 "backup-decision-time": now - datetime.timedelta(hours=1),
-                "backup-reason": "scheduled",
+                "backup-reason": BackupReason.scheduled,
                 "normalized-backup-time": metadata["normalized-backup-time"],
             },
             "name": "name01",
@@ -763,7 +763,7 @@ LABEL: pg_basebackup base backup
         now2 = now + datetime.timedelta(hours=1)
         metadata = pghoard.get_new_backup_details(now=now2, site=pghoard.test_site, site_config=site_config)
         assert metadata
-        assert metadata["backup-reason"] == "scheduled"
+        assert metadata["backup-reason"] == BackupReason.scheduled
         assert metadata["backup-decision-time"] == now2.isoformat()
         assert "T16:10:00+00:00" in metadata["normalized-backup-time"]
 
@@ -779,7 +779,7 @@ LABEL: pg_basebackup base backup
         now3 = now + datetime.timedelta(hours=7)
         metadata = pghoard.get_new_backup_details(now=now3, site=pghoard.test_site, site_config=site_config)
         assert metadata
-        assert metadata["backup-reason"] == "scheduled"
+        assert metadata["backup-reason"] == BackupReason.scheduled
         assert metadata["backup-decision-time"] == now3.isoformat()
         assert "T14:50:00+00:00" in metadata["normalized-backup-time"]
 
@@ -789,7 +789,7 @@ LABEL: pg_basebackup base backup
             "metadata": {
                 "start-time": now3 - datetime.timedelta(hours=1),
                 "backup-decision-time": now - datetime.timedelta(hours=1),
-                "backup-reason": "requested",
+                "backup-reason": BackupReason.requested,
                 "normalized-backup-time": metadata["normalized-backup-time"] + "different",
             },
             "name": "name02",
@@ -807,7 +807,7 @@ LABEL: pg_basebackup base backup
         pghoard.requested_basebackup_sites.add(site)
         metadata2 = pghoard.get_new_backup_details(now=now3, site=pghoard.test_site, site_config=site_config)
         assert metadata2
-        assert metadata2["backup-reason"] == "requested"
+        assert metadata2["backup-reason"] == BackupReason.requested
         assert metadata2["backup-decision-time"] == now3.isoformat()
         assert metadata2["normalized-backup-time"] == metadata["normalized-backup-time"]
 
@@ -827,7 +827,7 @@ LABEL: pg_basebackup base backup
         pghoard.patch_basebackup_info(entry=entry, site_config=site_config)
         assert entry["name"] == "bar"
         assert entry["metadata"]["start-time"] == now
-        assert entry["metadata"]["backup-reason"] == "scheduled"
+        assert entry["metadata"]["backup-reason"] == BackupReason.scheduled
         assert entry["metadata"]["backup-decision-time"] == now
         assert isinstance(entry["metadata"]["normalized-backup-time"], str)
 
@@ -836,14 +836,14 @@ LABEL: pg_basebackup base backup
             "metadata": {
                 "start-time": now.isoformat(),
                 "backup-decision-time": (now - datetime.timedelta(seconds=30)).isoformat(),
-                "backup-reason": "requested",
+                "backup-reason": BackupReason.requested,
                 "normalized-backup-time": None,
             }
         }
         pghoard.patch_basebackup_info(entry=entry, site_config=site_config)
         assert entry["name"] == "bar"
         assert entry["metadata"]["start-time"] == now
-        assert entry["metadata"]["backup-reason"] == "requested"
+        assert entry["metadata"]["backup-reason"] == BackupReason.requested
         assert entry["metadata"]["backup-decision-time"] == now - datetime.timedelta(seconds=30)
         assert entry["metadata"]["normalized-backup-time"] is None
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,7 @@ from rohmu.snappyfile import snappy
 from pghoard import config as pghconfig
 from pghoard import logutil, pgutil
 from pghoard.archive_cleanup import ArchiveCleanup
+from pghoard.common import BackupReason
 from pghoard.pghoard import PGHoard
 
 logutil.configure_logging()
@@ -491,7 +492,7 @@ def fixture_archive_cleaner(tmp_path):
     bb_metadata = {
         "_hash": "abc",
         "backup-decision-time": "2022-03-23T14:57:55.883514+00:00",
-        "backup-reason": "scheduled",
+        "backup-reason": BackupReason.scheduled,
         "start-time": "2022-03-23T15:57:55+01:00",
         "start-wal-segment": "000000010000000000000002",
         "active-backup-mode": "basic",

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -900,6 +900,7 @@ class TestPGHoardWithPG:
         os.makedirs(wal_directory, exist_ok=True)
 
         pghoard.receivexlog_listener(pghoard.test_site, db.user, wal_directory)
+        time.sleep(0.5)  # waiting for thread setup
         conn = db.connect()
         conn.autocommit = True
 
@@ -918,6 +919,7 @@ class TestPGHoardWithPG:
         # stopping the thread is not enough, it's possible that killed receiver will leave incomplete partial files
         # around, pghoard is capable of cleaning those up but needs to be restarted, for the test it should be OK
         # just to call startup_walk_for_missed_files, so it takes care of cleaning up
+        time.sleep(0.5)  # waiting for the end of file processing
         pghoard.startup_walk_for_missed_files()
 
         n_xlogs = pghoard.transfer_agent_state[pghoard.test_site]["upload"]["xlog"]["xlogs_since_basebackup"]
@@ -930,6 +932,7 @@ class TestPGHoardWithPG:
         # restart
         pghoard.receivexlog_listener(pghoard.test_site, db.user, wal_directory)
         assert pghoard.receivexlogs[pghoard.test_site].is_alive()
+        time.sleep(0.5)  # waiting for thread setup
 
         # We should now process all created segments, not only the ones which were created after pg_receivewal was restarted
         wait_for_xlog(pghoard, n_xlogs + 10)

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -17,7 +17,7 @@ import pytest
 
 import pghoard.pghoard as pghoard_module
 from pghoard.common import (
-    TAR_METADATA_FILENAME, BaseBackupFormat, FileType, create_alert_file, delete_alert_file, write_json_file
+    TAR_METADATA_FILENAME, BackupReason, BaseBackupFormat, FileType, create_alert_file, delete_alert_file, write_json_file
 )
 from pghoard.pghoard import PGHoard
 from pghoard.pgutil import create_connection_string
@@ -92,7 +92,7 @@ dbname|"""
         assert available_backup["name"] == "2015-07-03_0"
         start_time = datetime.datetime(2015, 7, 3, 12, tzinfo=datetime.timezone.utc)
         assert available_backup["metadata"]["start-time"] == start_time
-        assert available_backup["metadata"]["backup-reason"] == "scheduled"
+        assert available_backup["metadata"]["backup-reason"] == BackupReason.scheduled
         assert available_backup["metadata"]["normalized-backup-time"] is None
         assert available_backup["metadata"]["backup-decision-time"]
 


### PR DESCRIPTION
Pghoard will try making backup in this cases, еven if the retries are over:
1. Backup was requested by operator (called related http endpoint)
2. More than `backup_interval` have passed since the last unsuccessful attempt

[BF-2390]

Pghoard can stuck in state, when it doesn't make backup after several failures. It just writes in log `Giving up backup after exceeding max retries` and only restart can help.

