### PR TITLE
refactor progress based basebackup metrics

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -564,8 +564,6 @@ class PGBaseBackup(PGHoardThread):
                 db_conn.commit()
 
                 self.log.info("Starting to backup %r and %r tablespaces to %r", pgdata, len(tablespaces), compressed_base)
-                progress_instance = PersistedProgress()
-                progress_instance.reset_all(metrics=self.metrics)
                 start_time = time.monotonic()
 
                 if delta:
@@ -686,6 +684,8 @@ class PGBaseBackup(PGHoardThread):
                     "%r byte input, %r byte output, took %r seconds, waiting to upload", total_file_count, chunks_count,
                     total_size_plain, total_size_enc, backup_time
                 )
+                progress_instance = PersistedProgress()
+                progress_instance.reset_all(metrics=self.metrics)
 
             finally:
                 db_conn.rollback()

--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -94,6 +94,10 @@ class DeltaBaseBackup:
                     persisted_progress.write(self.metrics)
                     self.last_flush_time = time.monotonic()
                     self.metrics.gauge("pghoard.seconds_since_backup_progress_stalled", 0, tags=tags)
+                    self.log.info(
+                        "Updated snapshot progress for %s to %d files; elapsed time since last check: %.2f seconds.",
+                        progress_step.value, progress_data["handled"], elapsed
+                    )
                 else:
                     stalled_age = progress_info.age
                     self.metrics.gauge("pghoard.seconds_since_backup_progress_stalled", stalled_age, tags=tags)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -92,36 +92,25 @@ class TestCommon(PGHoardTestCase):
     def test_persisted_progress(self, mocker, tmp_path):
         test_progress_file = tmp_path / "test_progress.json"
         original_time = 1625072042.123456
-        test_data = {
-            "progress": {
-                "0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b": {
-                    "current_progress": 100,
-                    "last_updated_time": original_time
-                }
-            }
-        }
+        test_data = {"progress": {"total_bytes_uploaded": {"current_progress": 100, "last_updated_time": original_time}}}
 
         with open(test_progress_file, "w") as file:
             json.dump(test_data, file)
 
         mocker.patch("pghoard.common.PROGRESS_FILE", test_progress_file)
         persisted_progress = PersistedProgress.read(metrics=metrics.Metrics(statsd={}))
-        assert "0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b" in persisted_progress.progress
-        assert persisted_progress.progress["0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b"
-                                           ].current_progress == 100
-        assert persisted_progress.progress["0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b"
-                                           ].last_updated_time == 1625072042.123456
+        assert "total_bytes_uploaded" in persisted_progress.progress
+        assert persisted_progress.progress["total_bytes_uploaded"].current_progress == 100
+        assert persisted_progress.progress["total_bytes_uploaded"].last_updated_time == 1625072042.123456
 
         new_progress = 200
-        progress_info = persisted_progress.get("0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b")
+        progress_info = persisted_progress.get("total_bytes_uploaded")
         progress_info.update(new_progress)
         persisted_progress.write(metrics=metrics.Metrics(statsd={}))
 
         updated_progress = PersistedProgress.read(metrics=metrics.Metrics(statsd={}))
-        assert updated_progress.progress["0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b"
-                                         ].current_progress == new_progress
-        assert updated_progress.progress["0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b"
-                                         ].last_updated_time > original_time
+        assert updated_progress.progress["total_bytes_uploaded"].current_progress == new_progress
+        assert updated_progress.progress["total_bytes_uploaded"].last_updated_time > original_time
 
     def test_default_persisted_progress_creation(self, mocker, tmp_path):
         tmp_file = tmp_path / "non_existent_progress.json"

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -337,6 +337,6 @@ class TestTransferAgent(PGHoardTestCase):
         self.transfer_agent.handle_upload("test_site", self.foo_basebackup_path, upload_event)
         updated_progress = PersistedProgress.read(metrics=metrics.Metrics(statsd={}))
         assert temp_progress_file.exists()
-        assert updated_progress.progress[self.foo_basebackup_path].current_progress == 3
+        assert updated_progress.progress["total_bytes_uploaded"].current_progress == 3
         if temp_progress_file.exists():
             temp_progress_file.unlink()


### PR DESCRIPTION
This PR refactors the basebackups monitoring introduced in PR #615. Previously, we reset the basebackup progress file whenever a new basebackup request was made, which resulted in not catching a few cases where pghoard restarts. Now, the progress file is only reset when a backup is successful, and we also record the total bytes uploaded in the file for the previous basebackup. If there is a retry due to a pghoard restart or a failed backup request, we check if progress has been made; if it has not exceeded the bytes uploaded in the previous state, we emit a stalled metric. Also, added logging for upload progress for each file and snapshot stages in a basebackup operation.

[SRE-7476]

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

