### PR TITLE
fix: Reduce the stalled logging for snapshot

### DIFF
--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -412,9 +412,8 @@ class TransferAgent(PGHoardThread):
             if file_to_transfer.callback_queue:
                 file_to_transfer.callback_queue.put(result)
 
-            operation_type = file_to_transfer.operation
             status = "FAILED" if not result.success else "successfully"
-            log_msg = f"{operation_type.capitalize()} of key: {key}, " \
+            log_msg = f"{oper.capitalize()} of key: {key}, " \
                       f"size: {oper_size}, {status} in {time.monotonic() - start_time:.3f}s"
             self.log.info(log_msg)
 


### PR DESCRIPTION
Reduce the stalled logging for the snapshot process. Previously, we were not resetting last_flush_time, resulting in a lot of logs being printed if the previous base backup failed and the current progress surpassed the previous base backup progress for the snapshot process

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

