### PR TITLE
webserver: support authentication on the webserver

### DIFF
--- a/pghoard.spec
+++ b/pghoard.spec
@@ -20,6 +20,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-flake8
 BuildRequires:  python3-pylint
 BuildRequires:  python3-pytest
+BuildRequires:  systemd
 
 %undefine _missing_build_ids_terminate_build
 %define debug_package %{nil}

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -91,6 +91,8 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
     config.setdefault("backup_location", None)
     config.setdefault("http_address", PGHOARD_HOST)
     config.setdefault("http_port", PGHOARD_PORT)
+    config.setdefault("webserver_username", None)
+    config.setdefault("webserver_password", None)
     config.setdefault("alert_file_dir", config.get("backup_location") or os.getcwd())
     config.setdefault("json_state_file_path", "/var/lib/pghoard/pghoard_state.json")
     config.setdefault("maintenance_mode_file", "/var/lib/pghoard/maintenance_mode_file")

--- a/pghoard/object_store.py
+++ b/pghoard/object_store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 from requests import Session
+from requests.auth import HTTPBasicAuth
 from rohmu import dates
 
 
@@ -72,14 +73,16 @@ class ObjectStore:
 
 
 class HTTPRestore(ObjectStore):
-    def __init__(self, host, port, site, pgdata=None):
+    def __init__(self, host, port, site, pgdata=None, *, username=None, password=None):
         super().__init__(storage=None, prefix=None, site=site, pgdata=pgdata)
         self.host = host
         self.port = port
         self.session = Session()
+        if username and password:
+            self.session.auth = HTTPBasicAuth(username, password)
 
     def _url(self, path):
-        return "http://{host}:{port}/{site}/{path}".format(host=self.host, port=self.port, site=self.site, path=path)
+        return f"http://{self.host}:{self.port}/{self.site}/{path}"
 
     def list_basebackups(self):
         response = self.session.get(self._url("basebackup"))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -277,6 +277,11 @@ def fixture_pghoard(db, tmpdir, request):
     yield from pghoard_base(db, tmpdir, request)
 
 
+@pytest.fixture(name="pghoard_with_userauth")
+def fixture_pghoard_with_userauth(db, tmpdir, request):
+    yield from pghoard_base(db, tmpdir, request, username="testuser", password="testpass")
+
+
 @pytest.fixture(name="pghoard_ipv4_hostname")
 def fixture_pghoard_ipv4_hostname(db, tmpdir, request):
     yield from pghoard_base(db, tmpdir, request, listen_http_address="localhost")
@@ -362,7 +367,9 @@ def pghoard_base(
     active_backup_mode="pg_receivexlog",
     slot_name=None,
     compression_count=None,
-    listen_http_address="127.0.0.1"
+    listen_http_address="127.0.0.1",
+    username=None,
+    password=None
 ):
     test_site = request.function.__name__
 
@@ -417,6 +424,10 @@ def pghoard_base(
 
     if compression_count is not None:
         config["compression"]["thread_count"] = compression_count
+
+    if username is not None and password is not None:
+        config["webserver_username"] = username
+        config["webserver_password"] = password
 
     confpath = os.path.join(str(tmpdir), "config.json")
     with open(confpath, "w") as fp:


### PR DESCRIPTION
# About this change - What it does

Support requesting authentication on the web server. This is intended to limit exposure from local redirects, open proxies and/or call out functionality.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

