### PR TITLE
Add more retries when restoring a basebackup

### DIFF
--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -607,8 +607,8 @@ class Restore:
                 os.chmod(dirname, 0o700)
 
         # Based on limited samples, there could be one stalled download per 122GiB of transfer
-        # So we tolerate one stall for every 64GiB of transfer (or STALL_MIN_RETRIES for smaller backup)
-        stall_max_retries = max(STALL_MIN_RETRIES, int(int(metadata.get("total-size-enc", 0)) / (64 * 2 ** 30)))
+        # So we tolerate one stall for every 10GiB of transfer (or STALL_MIN_RETRIES for smaller backup)
+        stall_max_retries = max(STALL_MIN_RETRIES, int(int(metadata.get("total-size-enc", 0)) / (10 * 2 ** 30)))
 
         fetcher = BasebackupFetcher(
             app_config=self.config,


### PR DESCRIPTION
Commit 4869d8491cb6df9ced1613af1be5a3fd3dfbc358 added logic to make the number of retries dependent on the backup size. Instead of allowing for one error every 64GB allow for one every 10GB.

It's better to retry more than to start from scratch when things go wrong.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

