### PR TITLE
One more occurence of making pg_wal contents disappear

### DIFF
--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -189,6 +189,7 @@ class TestWebServer:
         )
         assert os.path.exists(output_path)
         os.unlink(output_path)
+        os.unlink(valid_wal_path)
 
         with pytest.raises(postgres_command.PGCError):
             restore_command(
@@ -601,8 +602,11 @@ class TestWebServer:
         status = conn.getresponse().status
         assert status == 201
 
+        # This test used to ensure we deleted files from the pg_xlog directory
+        # It now tests that if the operation results in a copy, the original file
+        # is still copied instead of being removed
         with open(storage_name, "rb") as f:
-            assert f.read() == storage_data
+            assert f.read() == on_disk_data
 
     def test_restore_command_retry(self, pghoard):
         failures = [0, ""]


### PR DESCRIPTION
If PostgreSQL asks for a file, we need to copy it there not rename it if it already exists.

This is the case when PG asks for a timeline to be copied over to RECOVERYTIMELINE.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

