### PR TITLE
Use --no-sync for pg_receivewal

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -265,7 +265,7 @@ class PGHoard:
         # Depending on the PG version, we must react either to MOVE (pre-PG10)
         # or CLOSE_WRITE (PG10+)
         if pg_version_server >= 100000:
-            events = ["IN_CLOSE_WRITE"]
+            events = ["IN_CLOSE_WRITE", "IN_MOVED_TO", "IN_MOVED_FROM"]
         else:
             events = ["IN_MOVED_TO", "IN_MOVED_FROM"]
         events += ["IN_DELETE_SELF"]

--- a/pghoard/receivexlog.py
+++ b/pghoard/receivexlog.py
@@ -45,6 +45,7 @@ class PGReceiveXLog(PGHoardThread):
             "--status-interval",
             "1",
             "--verbose",
+            "--no-sync",
             "--directory",
             self.wal_location,
         ]


### PR DESCRIPTION


Since we are only ever dumping it to a temp directory, use the --no-sync
argument.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

