### PR TITLE
Fix --no-sync flag usage

### DIFF
--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -7,6 +7,7 @@ See LICENSE for details
 import json
 import multiprocessing
 import os
+import shlex
 import subprocess
 from typing import Optional
 
@@ -29,6 +30,7 @@ def get_command_version(command: str, can_fail=True) -> Optional[str]:
     Run the given command identified by it's full path with the --version
     option.
     """
+    command = shlex.split(command)[0]
     if os.path.exists(command) and os.access(command, os.X_OK):
         try:
             version_output = subprocess.check_output([command, "--version"])

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -264,10 +264,7 @@ class PGHoard:
 
         # Depending on the PG version, we must react either to MOVE (pre-PG10)
         # or CLOSE_WRITE (PG10+)
-        if pg_version_server >= 100000:
-            events = ["IN_CLOSE_WRITE", "IN_MOVED_TO", "IN_MOVED_FROM"]
-        else:
-            events = ["IN_MOVED_TO", "IN_MOVED_FROM"]
+        events = ["IN_MOVED_TO", "IN_MOVED_FROM"]
         events += ["IN_DELETE_SELF"]
 
         self.inotify.add_watch(wal_directory, events)

--- a/pghoard/receivexlog.py
+++ b/pghoard/receivexlog.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 import os
 import select
+import shlex
 import signal
 import subprocess
 import time
@@ -41,7 +42,7 @@ class PGReceiveXLog(PGHoardThread):
         self.running = True
 
         command = [
-            self.config["backup_sites"][self.site]["pg_receivexlog_path"],
+            *shlex.split(self.config["backup_sites"][self.site]["pg_receivexlog_path"]),
             "--status-interval",
             "1",
             "--verbose",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -277,6 +277,12 @@ def fixture_pghoard(db, tmpdir, request):
     yield from pghoard_base(db, tmpdir, request)
 
 
+@pytest.fixture(name="pghoard_nosync")
+def fixture_pghoard_nosync(db, tmpdir, request):
+    receive_xlog_path = str(Path(db.bindir) / "pg_receive_wal") + " --no-sync"
+    yield from pghoard_base(db, tmpdir, request, pg_receivexlog_path=receive_xlog_path)
+
+
 @pytest.fixture(name="pghoard_with_userauth")
 def fixture_pghoard_with_userauth(db, tmpdir, request):
     yield from pghoard_base(db, tmpdir, request, username="testuser", password="testpass")
@@ -369,7 +375,8 @@ def pghoard_base(
     compression_count=None,
     listen_http_address="127.0.0.1",
     username=None,
-    password=None
+    password=None,
+    pg_receivexlog_path=None,
 ):
     test_site = request.function.__name__
 
@@ -392,6 +399,7 @@ def pghoard_base(
                 "pg_bin_directory": db.pgbin,
                 "pg_data_directory": db.pgdata,
                 "pg_receivexlog": pg_receivexlog_config or {},
+                "pg_receivexlog_path": pg_receivexlog_path,
                 "nodes": [node],
                 "object_storage": {
                     "storage_type": "local",

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -895,6 +895,7 @@ class TestPGHoardWithPG:
         wait_for_xlog(pghoard, 15)
         assert "pausing pg_receive(wal|xlog)" in caplog.text
 
+    @pytest.mark.parametrize("pghoard", ["pghoard", "pghoard_nosync"], indirect=["pghoard"])
     def test_surviving_pg_receivewal_hickup(self, db, pghoard):
         wal_directory = os.path.join(pghoard.config["backup_location"], pghoard.test_site, "xlog_incoming")
         os.makedirs(wal_directory, exist_ok=True)


### PR DESCRIPTION
Instead of passing it in all cases, allow pg_receive_xlog_path to be a command and pass it as is. 

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

